### PR TITLE
Fix portfolio card heights

### DIFF
--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -6,29 +6,30 @@ export default function Portfolio() {
     <section id="portfolio" className="section">
       <div className="container">
         <h2 className="h2">作品</h2>
-        <div className="mt-8 grid md:grid-cols-3 gap-6">
+        <div className="mt-8 grid md:grid-cols-3 gap-6 auto-rows-fr">
           {PROJECTS.map((p) => (
-            <motion.a
-              key={p.title}
-              href={p.href}
-              target="_blank"
-              className="card p-5 hover:shadow-lg transition-shadow"
-              initial={{ opacity: 0, y: 16 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, amount: 0.2 }}
-              transition={{ duration: 0.4 }}
-            >
-              <div className="aspect-[16/10] w-full rounded-xl bg-gradient-to-br from-sky-100 to-amber-100 border flex items-center justify-center text-slate-700">
-                <span className="font-semibold">{p.preview}</span>
-              </div>
-              <div className="h3 mt-4">{p.title}</div>
-              <p className="text-sm text-slate-600 mt-1">{p.desc}</p>
-              <div className="mt-3 flex flex-wrap gap-2">
-                {p.tags.map((t) => (
-                  <span key={t} className="badge">{t}</span>
-                ))}
-              </div>
-            </motion.a>
+            <div key={p.title} className="h-full flex flex-col">
+              <motion.a
+                href={p.href}
+                target="_blank"
+                className="card p-5 hover:shadow-lg transition-shadow h-full flex flex-col"
+                initial={{ opacity: 0, y: 16 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true, amount: 0.2 }}
+                transition={{ duration: 0.4 }}
+              >
+                <div className="aspect-[16/10] w-full rounded-xl bg-gradient-to-br from-sky-100 to-amber-100 border flex items-center justify-center text-slate-700">
+                  <span className="font-semibold">{p.preview}</span>
+                </div>
+                <div className="h3 mt-4">{p.title}</div>
+                <p className="text-sm text-slate-600 mt-1">{p.desc}</p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {p.tags.map((t) => (
+                    <span key={t} className="badge">{t}</span>
+                  ))}
+                </div>
+              </motion.a>
+            </div>
           ))}
         </div>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,6 @@
 .h2 { @apply font-heading text-2xl sm:text-3xl font-bold tracking-tight; }
 .h3 { @apply font-heading text-xl sm:text-2xl font-semibold; }
 .badge { @apply inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm font-medium bg-white/80 backdrop-blur border-slate-200; }
-.card { @apply rounded-2xl border border-slate-200 bg-white shadow-soft; }
+.card { @apply rounded-2xl border border-slate-200 bg-white shadow-soft min-h-80; }
 .lead { @apply text-lg text-slate-600; }
 .link { @apply underline decoration-2 underline-offset-4 hover:decoration-4; }


### PR DESCRIPTION
## Summary
- Ensure portfolio grid items stretch uniformly
- Add baseline minimum height to card utility class

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5987c84d083328dbba60e981a6dcc